### PR TITLE
Easy Solution & small functionality addition

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -305,12 +305,17 @@ impl Context {
 
     pub fn field_of(&self, person: &Person) -> Option<&Field> {
         use Person::*;
-        self.field_assignment.get(match person {
-            Alice => 0,
-            Bob => 1,
-            Charlie => 2,
-            Dan => 3,
-        })
+        match person {
+            Alice => self.field_assignment.get(0),
+            Bob => self.field_assignment.get(1),
+            Charlie => self.field_assignment.get(2),
+            Dan => self.field_assignment.get(3),
+
+            Mathematician => Some(&Field::Mathematics),
+            Physicist => Some(&Field::Physics),
+            Engineer => Some(&Field::Engineering),
+            Philosopher => Some(&Field::Philosophy),
+        }
     }
 
     pub fn ask(&mut self, src: String) -> Result<(), InterpretError> {

--- a/strats/game/consts.py
+++ b/strats/game/consts.py
@@ -6,6 +6,11 @@ Bob     = types.Person("Bob",     1)
 Charlie = types.Person("Charlie", 2)
 Dan     = types.Person("Dan",     3)
 
+Mathematician = types.Person("Mathematician", 4)
+Physicist     = types.Person("Physicist",     5)
+Engineer      = types.Person("Engineer",      6)
+Philosopher   = types.Person("Philosopher",   7)
+
 # responses
 Foo = types.Response("foo")
 Bar = types.Response("bar")

--- a/submissions/itr.py
+++ b/submissions/itr.py
@@ -1,0 +1,16 @@
+from strats import *
+
+
+class Strategy(Easy):
+    question_limit = 1
+
+    def solve(self):
+        # To Alice: Does the mathematician use the word "Foo" as "No"?
+        response = self.get_response(Alice.ask(Foo.equals(Mathematician.ask(False))))
+        if response == Bar:
+            self.guess[Alice] = Math
+            self.guess[Bob] = Phys
+        else:
+            self.guess[Alice] = Phys
+            self.guess[Bob] = Math
+


### PR DESCRIPTION
### Solution
Asks Alice the question `Does the mathematician use the word "Foo" as "No"?`

### Engine Changes
Modifies the engine to allow asking what the person with a specific profession would answer, because even if *we* don't know who that is, the people we're asking clearly do. It makes sure to disallow having the main askee be a profession, since you don't know who to ask unless you already know who has that profession.

I ended up implementing it by adding the professions as people, as I didn't like the two other ways I could think of implementing it. 
**Alternative 1** was making Person::parse_in_context able to find the correct person from Field, but that would require extra logic for finding out who was assigned the field and it would also reveal the name of the person in the interactive version.
**Alternative 2** was implementing Either<Person,Field> and making methods use that instead, but that would require touching a lot more methods.