### PR TITLE
Use rustyline so we can have history for questions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 rand = { version = "0.8.5" }
 colored = { version = "2.1.0" }
 itertools = { version = "0.13.0", optional = true }
+rustyline = { version = "14.0.0", default-features = false }
 
 [features]
 # de-randomise field assignments and word assignments (for testing)


### PR DESCRIPTION
Though not strictly necessary, it may be nice, especially when experimenting with the project, to be able to click the up arrow and have it actually go to your previous question. Rustyline allows us to do that, on top of having good line editing features, even if they may be better suited to command-driven applications.