### PR TITLE
Added question complexity metric

### DIFF
--- a/strats/_backend.py
+++ b/strats/_backend.py
@@ -49,16 +49,19 @@ class _StrategyBase:
         if (ret := self.solve()) is not None:
             raise ValueError(f"Solver should not return anything, but returned {ret}.")
         self._instance.guess(**self._guess)
-        return self._instance._question_counter
-    
+        return self._instance._question_counter, self._instance._question_complexity
+
     def test_all_cases(self):
         question_count = 0
+        question_complexity = 0
         case_count = 0
         while self._instance.is_running() and self._instance.ping():
-            question_count += self.single_case()
+            count, complexity = self.single_case()
+            question_count += count
+            question_complexity += complexity
             case_count += 1
 
-        return question_count / case_count
+        return question_count / case_count, question_complexity / case_count
 
 
 

--- a/strats/scoring/consts.py
+++ b/strats/scoring/consts.py
@@ -24,5 +24,6 @@ class KEYS:
     Q_LIMIT  = "question_limit"
 
     Q_AVG = "question_avg"
+    QC_AVG = "question_complexity_avg"
     CPLX = "complexity"
 

--- a/strats/scoring/runner.py
+++ b/strats/scoring/runner.py
@@ -35,10 +35,13 @@ class Submission:
 
         if (entry := table.get(self._fullpath)) is None:
             return
-        
+
         if (q_avg := entry.get(KEYS.Q_AVG)) is not None:
             self._q_avg: float = q_avg
-        
+
+        if (qc_avg := entry.get(KEYS.QC_AVG)) is not None:
+            self._qc_avg: float = qc_avg
+
         if (cplx := entry.get(KEYS.CPLX)) is not None:
             self._cplx: int = cplx
 
@@ -55,9 +58,9 @@ class Submission:
             entry[KEYS.AUTHOR] = author
         if accepted is not None:
             entry[KEYS.ACCEPTED] = accepted
-        
+
         entry[KEYS.Q_LIMIT] = self.get_question_limit()
-        entry[KEYS.Q_AVG] = self.get_question_average(recompute=recompute_q_avg)
+        entry[KEYS.Q_AVG], entry[KEYS.QC_AVG] = self.get_question_average(recompute=recompute_q_avg)
         entry[KEYS.CPLX] = self.get_complexity(recompute=recompute_cplx)
 
 
@@ -68,14 +71,14 @@ class Submission:
         return self._strategy.get_question_limit()
     
     def get_question_average(self, *, recompute=False) -> float:
-        if recompute or not hasattr(self, "_q_avg"):
+        if recompute or not hasattr(self, "_q_avg") or not hasattr(self, "_qc_avg"):
             print("Running strategy...")
-            self._q_avg = self._strategy.test_all_cases()
+            self._q_avg, self._qc_avg = self._strategy.test_all_cases()
 
             print("All scenarios passed!")
             print("Average number of questions needed:", self._q_avg)
 
-        return self._q_avg
+        return self._q_avg, self._qc_avg
     
     def get_complexity(self, *, recompute=False) -> int:
         if recompute or not hasattr(self, "_cplx"):

--- a/strats/scoring/scoreboard.py
+++ b/strats/scoring/scoreboard.py
@@ -6,7 +6,7 @@ import os
 def _sortkey(table: dict[str, dict]):
     def score(strat: str):
         entry = table[strat]
-        return (entry[KEYS.Q_AVG], entry[KEYS.CPLX], entry[KEYS.ACCEPTED])
+        return (entry[KEYS.Q_AVG], entry[KEYS.CPLX], entry[KEYS.QC_AVG], entry[KEYS.ACCEPTED])
     return score
 
 def load_scores() -> dict[str, dict[str, dict]]:
@@ -33,8 +33,8 @@ def update_scoreboard(difficulty: str, json: dict):
         file.write(f"# High scores for the \"{difficulty}\" variant\n\n")
         table = json[difficulty]
 
-        file.write("| Place | Strategy | Author | Questions | Complexity | Source |\n")
-        file.write("|:-----:|:--------:|:------:|:---------:|:----------:|:------:|\n")
+        file.write("| Place | Strategy | Author | Questions | Complexity | Question Complexity | Source |\n")
+        file.write("|:-----:|:--------:|:------:|:---------:|:----------:|:-------------------:|:------:|\n")
 
         for index, submission in enumerate(sorted(table, key=_sortkey(table))):
 
@@ -51,25 +51,26 @@ def update_scoreboard(difficulty: str, json: dict):
                 author = f"**{author}**"
             questions = f"{entry[KEYS.Q_AVG]:.5f}"
             complexity = f"{entry[KEYS.CPLX]:,}"
+            question_complexity = f"{entry[KEYS.QC_AVG]:.5f}"
             fname = os.path.relpath(submission, PATH.DIFFICULTY(difficulty))
             source = f"`{fname}`"
 
-            file.write(f"| {place} | {strategy} | {author} | {questions} | {complexity} | {source} |\n")
+            file.write(f"| {place} | {strategy} | {author} | {questions} | {complexity} | {question_complexity} | {source} |\n")
 
-def summary(fname: str, difficulty: str, questions: float, complexity: int, comment: str):
+def summary(fname: str, difficulty: str, questions: float, complexity: int, question_complexity: float, comment: str):
     if fname is None:
         return
-    
+
     with open(fname, 'a') as file:
         file.write("## Summary\n")
-        file.write("| Difficulty | Questions | Complexity | Comments |\n")
-        file.write("|:----------:|:---------:|:----------:|:--------:|\n")
-        file.write(f"| {difficulty} | {questions:.5f} | {complexity:,} | {comment} |\n\n")
+        file.write("| Difficulty | Questions | Complexity | Question Complexity | Comments |\n")
+        file.write("|:----------:|:---------:|:----------:|:-------------------:|:--------:|\n")
+        file.write(f"| {difficulty} | {questions:.5f} | {complexity:,} | {question_complexity:.5f} | {comment} |\n\n")
 
 def exception(fname: str, exc: Exception):
     if fname is None:
         return
-    
+
     with open(fname, 'a') as file:
         file.write("## Error\n")
         file.write("| Error | Message |\n")

--- a/submissions/public/scores.json
+++ b/submissions/public/scores.json
@@ -43,13 +43,6 @@
       "question_limit": 3,
       "question_avg": 3.0,
       "complexity": 95
-    },
-    "submissions/public/default/20241002_035437_itr.py": {
-      "author": "ITR13",
-      "accepted_on": "20241002_035437",
-      "question_limit": 3,
-      "question_avg": 3.0,
-      "complexity": 79
     }
   },
   "hard": {

--- a/test_strategy.py
+++ b/test_strategy.py
@@ -41,13 +41,14 @@ def process_single_submission(file: str|None, publish=False, author=None, summar
     print("Question limit:", submission.get_question_limit())
 
     print("Running submission...")
-    q_avg = submission.get_question_average()
+    q_avg, qc_avg = submission.get_question_average()
     cplx = submission.get_complexity()
-    scoring.scoreboard.summary(summary, submission.get_difficulty(), q_avg, cplx, f"Question limit: {submission.get_question_limit()}")
+    scoring.scoreboard.summary(summary, submission.get_difficulty(), q_avg, cplx, qc_avg, f"Question limit: {submission.get_question_limit()}")
 
     print("Submission passed all test cases!")
     print("Average question count:", q_avg)
     print("Solution complexity:", cplx)
+    print("Average question complexity:", qc_avg)
 
     if publish:
         if author is None:


### PR DESCRIPTION
Added a metric that measures the complexity of just the question asked after parsing. It uses the same regex used to measure the complexity of a string in complexity.py 

I added this mostly because I think it's interesting to have an additional complexity metric that doesn't care how the python code for the problem is written, just what questions get asked.